### PR TITLE
fix: check non-existing celery task id

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ celery = "^5.2.7"
 redis = "^4.5.1"
 
 [tool.pylint.messages_control]
-disable = "E1101, W0703, C0301, W0223"
+disable = "E1101, W0703, C0301, W0223, W0613"
 
 
 [build-system]

--- a/resources/scrape.py
+++ b/resources/scrape.py
@@ -86,7 +86,9 @@ class ScrapeStatus(Resource):
             tuple: JSON and status code
         """
         task_result = AsyncResult(task_id)
-        result = {
-            "task_status": task_result.status,
-        }
+        result = {"task_status": "Task id does not exists"}
+        if task_result.status != "PENDING":
+            result = {
+                "task_status": task_result.status,
+            }
         return result, 200

--- a/utils/celery_app.py
+++ b/utils/celery_app.py
@@ -1,6 +1,7 @@
 """Celery App"""
 
-from celery import Celery, Task
+from celery import Celery, Task, current_app
+from celery.signals import after_task_publish
 
 
 def init_celery(app) -> Celery:
@@ -18,3 +19,13 @@ def init_celery(app) -> Celery:
     app.extensions["celery"] = celery_app
     celery_app.set_default()
     return celery_app
+
+
+@after_task_publish.connect
+def update_sent_state(sender=None, headers=None, **kwargs):
+    """Changes the task state, helping to indentify non-existing tasks"""
+
+    task = current_app.tasks.get(sender)
+    backend = task.backend if task else current_app.backend
+
+    backend.store_result(headers["id"], None, "IN_PROGRESS")


### PR DESCRIPTION
Change state of new task to IN_PROGRESS which helps to identify non-existing task id's.

closes #35 